### PR TITLE
Use mbstring function over utf8_encode

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,9 @@
         "psr-0" : {"Idio": "lib"}
     },
     "require" : {
-        "jakeasmith/http_build_url": "0.1.*"
+        "jakeasmith/http_build_url": "0.1.*",
+        "ext-curl": "*",
+        "ext-mbstring": "*"
     },
     "require-dev" : {
         "phpunit/phpunit": "3.7.*"

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,11 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "53a9c994c13fbec3a185518b18e73c05",
+    "hash": "c381fd63857dcb4253f8eac672d80d72",
+    "content-hash": "af200e526bb5274fc3d9feb6e542ca9e",
     "packages": [
         {
             "name": "jakeasmith/http_build_url",
@@ -366,13 +367,13 @@
             "version": "1.2.3",
             "source": {
                 "type": "git",
-                "url": "git://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "1.2.3"
+                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
+                "reference": "5794e3c5c5ba0fb037b11d8151add2a07fa82875"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects/archive/1.2.3.zip",
-                "reference": "1.2.3",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/5794e3c5c5ba0fb037b11d8151add2a07fa82875",
+                "reference": "5794e3c5c5ba0fb037b11d8151add2a07fa82875",
                 "shasum": ""
             },
             "require": {
@@ -460,17 +461,14 @@
             "time": "2014-07-09 09:05:48"
         }
     ],
-    "aliases": [
-
-    ],
+    "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [
-
-    ],
-    "platform": [
-
-    ],
-    "platform-dev": [
-
-    ]
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "ext-curl": "*",
+        "ext-mbstring": "*"
+    },
+    "platform-dev": []
 }

--- a/lib/Idio/Api/Client.php
+++ b/lib/Idio/Api/Client.php
@@ -133,10 +133,9 @@ class Client
         $version = $this->getVersion();
         $path = ($version ? "/{$version}" : "") . $path;
 
-        $string = utf8_encode(
-            strtoupper($method) . "\n" .
-            $path . "\n" .
-            $this->date()
+        $string = mb_convert_encoding(
+            strtoupper($method) . "\n" .  $path . "\n" .  $this->date(),
+            'UTF-8'
         );
 
         return base64_encode(hash_hmac("sha1", $string, $secretKey));

--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,7 @@ This library is not concerned with the individual API endpoints. Instead it acts
 
 * PHP >= 5.3.2 
  * [cURL extension](http://php.net/manual/en/book.curl.php)
+ * [Multibyte String extension](http://php.net/manual/en/book.mbstring.php)
 * [PHPUnit](https://github.com/sebastianbergmann/phpunit/) – to run tests. (optional, installable via composer)
 
 ### Suggestions


### PR DESCRIPTION
The utf8 functions are no longer in core (as of PHP7 on ubuntu 16.04), so use mbstring equivalent.